### PR TITLE
Made it so the ID command isn't an embed

### DIFF
--- a/commands/id.js
+++ b/commands/id.js
@@ -3,8 +3,5 @@ const Discord = require("discord.js")
 module.exports.run = async (client, message, args, level) => {
     const msg = await message.channel.send("Loading...");
     let botuser = message.mentions.users.first() ? message.guild.members.get(message.mentions.users.first().id) : message.member
-    const embed = new Discord.RichEmbed()
-    .addField("ID", botuser.id)
-    .setColor(botuser.displayColor)
-    msg.edit(embed)
+    msg.edit(ID:\nbotuser.id)
 }


### PR DESCRIPTION
So that mobile users can copy it pretty much.

# Discord Information #
Discord Username w/ Discriminator: CarRoy#0001
Discord User ID: Can't copy my I'd :)



**What is this Pull Request for?**
changing the I'd command so that it isn't an embed
**Are you fixing an issue, if so, what is it?**
mobile users cant copy things from embeds
**What changes are being made in this pull request?**
removed the embed code and added other code
**Put any additional details below**
